### PR TITLE
Fix not working link for port 8080 for the lazy, with javascript

### DIFF
--- a/containers/apache/index.html
+++ b/containers/apache/index.html
@@ -4,7 +4,7 @@
     Jenkins is at : <a href="/jenkins">http://YOURHOST/jenkins</a><br>
     Artifactory is at: <a href="/artifactory/webapp">http://YOURHOST/artifactory/webapp</a><br>
     Docker Registry is at: <a href="/registry">http://YOURHOST/registry</a> (You will see a blank page! Not much helpful. ;) <br>
-    The Go Web Server (you will be compiling) will be at: <a href="http://YOURHOST:8080">http://YOURHOST:8080</a><br>
+    The Go Web Server (you will be compiling) will be at: <a href="" onclick="javascript:event.target.port=8080">http://YOURHOST:8080</a><br>
 
     <br>* Replace YOURHOST with the IP of your DockerHost.
 </p>


### PR DESCRIPTION
I have added a onclick to the last link, so lazy ppl can click direcly
